### PR TITLE
Canonical package name fix

### DIFF
--- a/lib/spindrift/packager.py
+++ b/lib/spindrift/packager.py
@@ -289,7 +289,17 @@ def get_package_from_name(type, package_name, renamed_packages, boto_handling="d
     if package_name is None:
         return None
 
-    package = pip._vendor.pkg_resources.working_set.by_key[package_name]
+    if package_name in pip._vendor.pkg_resources.working_set.by_key:
+        package = pip._vendor.pkg_resources.working_set.by_key[package_name]
+    else:
+        normalized_target = packaging.utils.canonicalize_name(package_name)
+        package = None
+        for pkg in pip._vendor.pkg_resources.working_set:
+            if packaging.utils.canonicalize_name(pkg.key) == normalized_target:
+                package = pkg
+                break
+        if package is None:
+            raise KeyError(package_name)
 
     # boto is available on lambda, don't always repackage it
     if package.key in ("boto3", "botocore") and boto_handling == "default":

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="spindrift",
-    version="5.6",
+    version="5.7",
     description="package python applications for AWS Lambda, AWS Elastic Beanstalk, AWS Batch (Docker)",
     author="Ryan P. Kelly",
     author_email="ryan@ryankelly.us",


### PR DESCRIPTION
Python's `pkg_resources.working_set` stores package keys inconsistently - some packages retain dots in their keys (e.g., `jaraco.text`), while others use dashes (e.g., `pdfminer-six`), with no uniform normalisation applied. When dependencies are specified in requirements with different separators than their stored keys (e.g., requesting `jaraco-text` when stored as `jaraco.text`, or requesting `pdfminer.six` when stored as `pdfminer-six`), direct dictionary lookups fail with KeyErrors. The fix requires comparing canonicalised package names rather than relying on the inconsistent key formats in `working_set.by_key`.

```
$ pip show pdfminer.six
Name: pdfminer.six
Version: 20250506
```
Error:
```
  File "/home/vagrant/.pyenv/versions/capitalrx/lib/python3.12/site-packages/spindrift/packager.py", line 106, in package
    dependencies_for_package = find_dependencies(
                               ^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/capitalrx/lib/python3.12/site-packages/spindrift/packager.py", line 222, in find_dependencies
    local_dependencies = _find_dependencies(
                         ^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/capitalrx/lib/python3.12/site-packages/spindrift/packager.py", line 264, in _find_dependencies
    requirement_package = get_package_from_name(
                          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/.pyenv/versions/capitalrx/lib/python3.12/site-packages/spindrift/packager.py", line 292, in get_package_from_name
    package = pip._vendor.pkg_resources.working_set.by_key[package_name]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'pdfminer.six'
```