### PR TITLE
fix namespace package copytree conflict with dirs_exist_ok

### DIFF
--- a/lib/spindrift/packager.py
+++ b/lib/spindrift/packager.py
@@ -849,6 +849,7 @@ def install_local_package(path, dependency, name):
                     source,
                     destination,
                     ignore=shutil.ignore_patterns(*IGNORED),
+                    dirs_exist_ok=True,
                 )
             else:
                 source = find_source_from_metadata(folder, name)
@@ -858,6 +859,7 @@ def install_local_package(path, dependency, name):
                         source,
                         destination,
                         ignore=shutil.ignore_patterns(*IGNORED),
+                        dirs_exist_ok=True,
                     )
                 else:
                     logger.warn(


### PR DESCRIPTION
when packaging projects that depend on namespace packages (for my case, `snowflake-connector-python` + `snowflake-sqlalchemy`), the `install_local_package` function fails because `shutil.copytree` can't copy to a destination that already exists.

happens when multiple packages share the same top-level directory (e.g., snowflake/), and the second copytree call fails with:

`FileExistsError: [Errno 17] File exists: '/var/tmp/tmpabc123/snowflake'`

proposed fix: add `dirs_exist_ok=True` to `copytree` calls, which merges directories instead of failing when the destination exists

testing:

patched my local spindrift installation and the packaging completed